### PR TITLE
Use ramda

### DIFF
--- a/packages/app/app.js
+++ b/packages/app/app.js
@@ -1,4 +1,4 @@
-import { reduce, append, merge } from '@northbrook/util'
+import { reduce, append, merge } from 'ramda'
 
 export const app = (...definitions) =>
   reduce(toType, { type: 'app', command: [] }, definitions)

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -30,6 +30,6 @@
   },
   "homepage": "https://github.com/tylors/reginn#readme",
   "dependencies": {
-    "@northbrook/util": "^1.0.2"
+    "ramda": "^0.22.1"
   }
 }

--- a/packages/command/command.js
+++ b/packages/command/command.js
@@ -1,4 +1,4 @@
-import { reduce, merge } from '@northbrook/util'
+import { reduce, merge } from 'ramda'
 
 export const command = (...definitions) =>
   reduce(toType, { type: TYPE }, definitions)

--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -26,6 +26,6 @@
   },
   "homepage": "https://github.com/tylors/reginn#readme",
   "dependencies": {
-    "@northbrook/util": "^1.0.2"
+    "ramda": "^0.22.1"
   }
 }

--- a/packages/flag/flag.js
+++ b/packages/flag/flag.js
@@ -1,11 +1,14 @@
-import { reduce, set } from '@northbrook/util'
+import { reduce } from 'ramda'
 
 export const flag = (...definitions) =>
   reduce(toType, {type: TYPE, flagType: 'string', alias: []}, definitions)
 
 function toType (acc, { type, value }) {
   switch (type) {
-    case 'type': return set(value, 'flagType', acc)
+    case 'type': {
+      acc.flagType = value
+      return acc
+    }
     case 'alias': {
       acc.alias = acc.alias.concat([ value ])
       return acc

--- a/packages/flag/package.json
+++ b/packages/flag/package.json
@@ -29,6 +29,6 @@
   },
   "homepage": "https://github.com/tylors/reginn#readme",
   "dependencies": {
-    "@northbrook/util": "^1.0.2"
+    "ramda": "^0.22.1"
   }
 }

--- a/packages/help/help.js
+++ b/packages/help/help.js
@@ -1,4 +1,3 @@
-import { map, filter, concat } from 'ramda'
 import { app } from '@reginn/app'
 import { command } from '@reginn/command'
 import { alias } from '@reginn/alias'
@@ -32,8 +31,8 @@ function buildHelpCommand (name, definitions) {
 
 function showHelp (name, definitions) {
   const apps = filterApp(definitions)
-  const cmds = concat(filterCommands(definitions), map(x => x.command, apps))
-  const flags = concat(filterFlag(definitions), map(x => x.flag, apps))
+  const cmds = apps.map(x => x.command).concat(filterCommands(definitions))
+  const flags = apps.map(x => x.flag).concat(filterFlag(definitions))
 
   return function ({ args, options }, description) {
     console.log(`  ${name.toUpperCase()}
@@ -58,7 +57,7 @@ function displayFlag ({ alias, desc }) {
 }
 
 const filterType = type => definitions =>
-  filter(x => x.type === type && !!x.desc && x.alias && x.alias[0][0], definitions)
+  definitions.filter(x => x.type === type && !!x.desc && x.alias && x.alias[0][0])
 
 const filterApp = filterType('app')
 const filterCommands = filterType('command')

--- a/packages/help/help.js
+++ b/packages/help/help.js
@@ -1,4 +1,4 @@
-import { map, filter, concat } from '@northbrook/util'
+import { map, filter, concat } from 'ramda'
 import { app } from '@reginn/app'
 import { command } from '@reginn/command'
 import { alias } from '@reginn/alias'

--- a/packages/help/package.json
+++ b/packages/help/package.json
@@ -30,7 +30,6 @@
     "@reginn/app": "^1.0.0",
     "@reginn/command": "^1.0.0",
     "@reginn/run": "^1.0.0",
-    "@reginn/stream": "^1.0.0",
-    "ramda": "^0.22.1"
+    "@reginn/stream": "^1.0.0"
   }
 }

--- a/packages/help/package.json
+++ b/packages/help/package.json
@@ -30,6 +30,7 @@
     "@reginn/app": "^1.0.0",
     "@reginn/command": "^1.0.0",
     "@reginn/run": "^1.0.0",
-    "@reginn/stream": "^1.0.0"
+    "@reginn/stream": "^1.0.0",
+    "ramda": "^0.22.1"
   }
 }

--- a/packages/run/package.json
+++ b/packages/run/package.json
@@ -26,6 +26,7 @@
   "homepage": "https://github.com/TylorS/reginn#readme",
   "dependencies": {
     "@northbrook/util": "^1.0.2",
-    "minimist": "^1.2.0"
+    "minimist": "^1.2.0",
+    "ramda": "^0.22.1"
   }
 }


### PR DESCRIPTION
Switch utiltiy functions to come from `ramda` instead of `@northbrook/util`. I plan to rewrite `@northbrook/util` and I don't see much reason to maintain a large set of utility functions when awesome libraries such as ramda and lodash-fp exist to solve these problems for us.
